### PR TITLE
[Suggestion] Add Charged Creepers as a spawnable mob

### DIFF
--- a/src/main/java/io/github/redstoneparadox/creeperfall/game/config/CreeperfallCreeperConfig.java
+++ b/src/main/java/io/github/redstoneparadox/creeperfall/game/config/CreeperfallCreeperConfig.java
@@ -10,7 +10,9 @@ public class CreeperfallCreeperConfig {
 			Codec.DOUBLE.fieldOf("spawn_count_increment").forGetter(config -> config.spawnCountIncrement),
 			Codec.INT.fieldOf("spawn_delay_secs").forGetter(config -> config.spawnDelaySeconds),
 			Codec.INT.fieldOf("spawn_height").forGetter(config -> config.spawnHeight),
-			Codec.doubleRange(0.0, 1.0).fieldOf("fall_speed_multiplier").forGetter(config -> config.fallSpeedMultiplier)
+			Codec.doubleRange(0.0, 1.0).fieldOf("fall_speed_multiplier").forGetter(config -> config.fallSpeedMultiplier),
+			Codec.intRange(0, 100).fieldOf("charged_spawn_percent").forGetter(config -> config.chargedSpawnStage),
+			Codec.INT.fieldOf("charged_spawn_stage").forGetter(config -> config.chargedSpawnStage)
 	).apply(instance, CreeperfallCreeperConfig::new));
 
 	public final int stages;
@@ -19,13 +21,17 @@ public class CreeperfallCreeperConfig {
 	public final int spawnDelaySeconds;
 	public final int spawnHeight;
 	public final double fallSpeedMultiplier;
+	public final int chargedSpawnStage;
+	public final int chargedSpawnPercent;
 
-	public CreeperfallCreeperConfig(int stages, int stageLengthSeconds, double spawnCountIncrement, int spawnDelaySeconds, int spawnHeight, double fallSpeedMultiplier) {
+	public CreeperfallCreeperConfig(int stages, int stageLengthSeconds, double spawnCountIncrement, int spawnDelaySeconds, int spawnHeight, double fallSpeedMultiplier, int chargedSpawnPercent, int chargedSpawnStage) {
 		this.stages = stages;
 		this.stageLengthSeconds = stageLengthSeconds;
 		this.spawnCountIncrement = spawnCountIncrement;
 		this.spawnDelaySeconds = spawnDelaySeconds;
 		this.spawnHeight = spawnHeight;
 		this.fallSpeedMultiplier = fallSpeedMultiplier;
+		this.chargedSpawnPercent = chargedSpawnPercent;
+		this.chargedSpawnStage = chargedSpawnStage;
 	}
 }

--- a/src/main/java/io/github/redstoneparadox/creeperfall/game/spawning/CreeperfallCreeperSpawnLogic.java
+++ b/src/main/java/io/github/redstoneparadox/creeperfall/game/spawning/CreeperfallCreeperSpawnLogic.java
@@ -6,6 +6,7 @@ import io.github.redstoneparadox.creeperfall.game.config.CreeperfallConfig;
 import io.github.redstoneparadox.creeperfall.game.map.CreeperfallMap;
 import io.github.redstoneparadox.creeperfall.game.util.EntityTracker;
 import io.github.redstoneparadox.creeperfall.game.util.Timer;
+import io.github.redstoneparadox.creeperfall.models.CreeperModel;
 import net.minecraft.entity.SpawnReason;
 import net.minecraft.entity.mob.CreeperEntity;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -27,6 +28,7 @@ public class CreeperfallCreeperSpawnLogic {
 	private final ServerWorld world;
 	private int currentStage = 1;
 	private boolean spawnedFirstWave = false;
+	private int chargedPercent = 35; // TODO: modify code to consider spawning rate
 
 	public CreeperfallCreeperSpawnLogic(GameSpace gameSpace, ServerWorld world, CreeperfallActive game, CreeperfallMap map, CreeperfallConfig config, EntityTracker tracker) {
 		this.gameSpace = gameSpace;
@@ -54,6 +56,7 @@ public class CreeperfallCreeperSpawnLogic {
 			spawnedFirstWave = true;
 		}
 
+
 		creeperIncreaseTimer.tick();
 		spawnTimer.tick();
 	}
@@ -69,6 +72,8 @@ public class CreeperfallCreeperSpawnLogic {
 
 		int minCreepers = playersRemaining;
 		int maxCreepers = MathHelper.floor(currentStage * config.creeperConfig.spawnCountIncrement * playersRemaining);
+
+		chargedPercent += (int) (currentStage * config.creeperConfig.spawnCountIncrement * playersRemaining);
 
 		int count = MathHelper.nextInt(random, minCreepers, maxCreepers);
 
@@ -91,6 +96,12 @@ public class CreeperfallCreeperSpawnLogic {
 		double z = random.nextInt(size - 2) + negativeBound + 1;
 
 		CreeperEntity entity = new CreeperfallCreeperEntity(this.world, config.creeperConfig.fallSpeedMultiplier, 0.02, 0.02);
+
+		// Randomise charged creepers
+		if (random.nextInt(100) <= chargedPercent)
+		{
+			((CreeperModel) entity).charge();
+		}
 
 		entity.setHealth(0.5f);
 		game.spawnEntity(entity, x, y, z, SpawnReason.NATURAL);

--- a/src/main/java/io/github/redstoneparadox/creeperfall/game/spawning/CreeperfallCreeperSpawnLogic.java
+++ b/src/main/java/io/github/redstoneparadox/creeperfall/game/spawning/CreeperfallCreeperSpawnLogic.java
@@ -28,9 +28,8 @@ public class CreeperfallCreeperSpawnLogic {
 	private final ServerWorld world;
 	private int currentStage = 1;
 	private boolean spawnedFirstWave = false;
-	private int chargedPercent = 35; // TODO: modify code to consider spawning rate
 
-	public CreeperfallCreeperSpawnLogic(GameSpace gameSpace, ServerWorld world, CreeperfallActive game, CreeperfallMap map, CreeperfallConfig config, EntityTracker tracker) {
+    public CreeperfallCreeperSpawnLogic(GameSpace gameSpace, ServerWorld world, CreeperfallActive game, CreeperfallMap map, CreeperfallConfig config, EntityTracker tracker) {
 		this.gameSpace = gameSpace;
 		this.world = world;
 		this.game = game;
@@ -73,8 +72,6 @@ public class CreeperfallCreeperSpawnLogic {
 		int minCreepers = playersRemaining;
 		int maxCreepers = MathHelper.floor(currentStage * config.creeperConfig.spawnCountIncrement * playersRemaining);
 
-		chargedPercent += (int) (currentStage * config.creeperConfig.spawnCountIncrement * playersRemaining);
-
 		int count = MathHelper.nextInt(random, minCreepers, maxCreepers);
 
 		for (int i = 0; i < count; i++) {
@@ -97,12 +94,12 @@ public class CreeperfallCreeperSpawnLogic {
 
 		CreeperEntity entity = new CreeperfallCreeperEntity(this.world, config.creeperConfig.fallSpeedMultiplier, 0.02, 0.02);
 
-		// Randomise charged creepers
-		if (random.nextInt(100) <= chargedPercent)
-		{
-			((CreeperModel) entity).charge();
+		if (currentStage >= config.creeperConfig.chargedSpawnStage) {        // Randomise charged creepers
+            int chargedPercent = config.creeperConfig.chargedSpawnPercent;
+            if (chargedPercent >= random.nextInt(100)) {
+				((CreeperModel) entity).charge();
+			}
 		}
-
 		entity.setHealth(0.5f);
 		game.spawnEntity(entity, x, y, z, SpawnReason.NATURAL);
 	}

--- a/src/main/java/io/github/redstoneparadox/creeperfall/mixin/CreeperEntityMixin.java
+++ b/src/main/java/io/github/redstoneparadox/creeperfall/mixin/CreeperEntityMixin.java
@@ -1,0 +1,55 @@
+package io.github.redstoneparadox.creeperfall.mixin;
+
+import io.github.redstoneparadox.creeperfall.models.CreeperModel;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.data.TrackedData;
+import net.minecraft.entity.mob.CreeperEntity;
+import net.minecraft.world.World;
+
+@Mixin(CreeperEntity.class)
+public abstract class CreeperEntityMixin extends Entity implements CreeperModel {
+    @Shadow
+    @Final
+    private static TrackedData<Boolean> CHARGED;
+
+    protected CreeperEntityMixin(EntityType<?> type, World world) {
+        super(type, world);
+    }
+
+    @Override
+    public boolean damage(DamageSource source, float amount) {
+        if (this.isCharged() && !(source.getSource() instanceof CreeperEntity))
+        {
+            discharge();
+            return super.damage(source, 0);
+        }
+        if (source.getSource() instanceof CreeperEntity)
+        {
+            return false;
+        }
+        return super.damage(source, amount);
+    }
+
+    @Override
+    public boolean isCharged()
+    {
+        return this.dataTracker.get(CHARGED);
+    }
+
+    @Override
+    public void charge()
+    {
+        this.dataTracker.set(CHARGED, true);
+    }
+
+    @Override
+    public void discharge() {
+        this.dataTracker.set(CHARGED, false);
+    }
+}

--- a/src/main/java/io/github/redstoneparadox/creeperfall/models/CreeperModel.java
+++ b/src/main/java/io/github/redstoneparadox/creeperfall/models/CreeperModel.java
@@ -1,0 +1,7 @@
+package io.github.redstoneparadox.creeperfall.models;
+
+public interface CreeperModel {
+    boolean isCharged();
+    void charge();
+    void discharge();
+}

--- a/src/main/resources/creeperfall.mixin.json
+++ b/src/main/resources/creeperfall.mixin.json
@@ -4,7 +4,8 @@
   "compatibilityLevel": "JAVA_16",
   "mixins": [
     "AbstractSkeletonEntityAccessor",
-    "GuardianEntityAccessor"
+    "GuardianEntityAccessor",
+    "CreeperEntityMixin"
   ],
   "client": [
   ],

--- a/src/main/resources/data/creeperfall/games/standard.json
+++ b/src/main/resources/data/creeperfall/games/standard.json
@@ -25,7 +25,9 @@
     "spawn_count_increment": 0.7,
     "spawn_delay_secs": 4,
     "spawn_height": 50,
-    "fall_speed_multiplier": 0.75
+    "fall_speed_multiplier": 0.75,
+    "charged_spawn_percent": 35,
+    "charged_spawn_stage": 3
   },
   "time_limit_secs": 200,
   "max_arrows": [4, 8, 12, 16, 20],


### PR DESCRIPTION
This adds #1.

# Feature
- Adds charged creepers as a spawnable mob

The charged creeper has a 30% chance of spawning in place of a normal creeper.
Shooting it will discharge it, turning it into a normal creeper.
The charged creeper is more powerful and deals more damage than a normal creeper.